### PR TITLE
Change the folder browser to include a text box for pasting a folder

### DIFF
--- a/v2/folder_select_dialog.go
+++ b/v2/folder_select_dialog.go
@@ -29,7 +29,7 @@ func (dlg *FolderSelectDialog) Execute(parent *Window) (bool, string) {
 	idl := w32.SHBrowseForFolder(&w32.BROWSEINFO{
 		Owner: owner,
 		Title: title,
-		Flags: w32.BIF_NEWDIALOGSTYLE,
+		Flags: w32.BIF_USENEWUI,
 	})
 	folder := w32.SHGetPathFromIDList(idl)
 


### PR DESCRIPTION
The folder browser is very unhelpful as it is currently. This is a quick fix to make it better.

If there is a way to replace it with the regular file dialog (just for folders) that would be way better.